### PR TITLE
Add description to XMLEncodingContainer

### DIFF
--- a/Sources/XMLParsing/XMLContainer.swift
+++ b/Sources/XMLParsing/XMLContainer.swift
@@ -57,7 +57,7 @@ class MutableDictionaryContainer<T> {
     }
 }
 
-enum XMLEncodingContainer {
+enum XMLEncodingContainer: CustomStringConvertible {
     case null
     case array(MutableArrayContainer<XMLEncodingContainer>)
     case dictionary(MutableDictionaryContainer<XMLEncodingContainer>)
@@ -78,6 +78,49 @@ enum XMLEncodingContainer {
     case float(Float)
     case double(Double)
     case decimal(Decimal)
+
+    var description: String {
+        switch self {
+        case .null:
+            return "NULL"
+        case .array(let array):
+            return "[\n\(array.values)\n]"
+        case .dictionary(let dictionary):
+            return "{\n\(dictionary.values)\n}"
+        case .string(let string):
+            return string
+
+        case .bool(let bool):
+            return bool ? "true" : "false"
+        case .int(let int):
+            return "\(int)"
+        case .int8(let int8):
+            return "\(int8)"
+        case .int16(let int16):
+            return "\(int16)"
+        case .int32(let int32):
+            return "\(int32)"
+        case .int64(let int64):
+            return "\(int64)"
+        case .uint(let uint):
+            return "\(uint)"
+        case .uint8(let uint8):
+            return "\(uint8)"
+        case .uint16(let uint16):
+            return "\(uint16)"
+        case .uint32(let uint32):
+            return "\(uint32)"
+        case .uint64(let uint64):
+            return "\(uint64)"
+
+        case .float(let float):
+            return "\(float)"
+        case .double(let double):
+            return "\(double)"
+        case .decimal(let decimal):
+            return "\(decimal)"
+        }
+    }
 }
 
 enum XMLDecodingContainer: CustomStringConvertible {


### PR DESCRIPTION
This fixes attribute encoding.

Consider the following example:

```swift
struct Book: Encodable {

    let id: String
    let title: String

    private enum CodingKeys: String, CodingKey {
        case id
        case title
    }

    func toXML() throws -> String {
        let encoder = XMLEncoder()
        encoder.attributeEncodingStrategy = .custom {
            guard let codingPath = $0.codingPath as? [CodingKeys] else {
                return false
            }

            switch codingPath {
            case [.id]:
                return true
            default:
                return false
            }
        }

        let data = try encoder.encode(self, withRootKey: "book")

        return String(data: data, encoding: .utf8)!
    }

}

let book = Book(id: "0001", title: "L’Étranger")
let xmlString = try! book.toXML()
print(xmlString)
```

Output before this patch:

```xml
<book id="string(&quot;0001&quot;)">
    <title>L’Étranger</title>
</book>
```

Output after this patch:

```xml
<book id="0001">
    <title>L’Étranger</title>
</book>
```